### PR TITLE
feat(guide): Document +1 Custom Format upgrades and cross-seed fix

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -353,15 +353,13 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
 ??? warning "Unwanted upgrades from single-point Custom Formats - [Click to show/hide]"
 
-    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`. This means a release only needs to score **1 point higher** than what you already have before Radarr treats it as an upgrade.
+    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`, so a release only needs `+1` more than what you already have to count as an upgrade.
 
-    Because of this, a Custom Format worth only `+1` — such as [{{ radarr['cf']['freeleech']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ radarr['cf']['p2p-internal']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"} — is enough on its own to trigger an upgrade.
+    A Custom Format worth only `+1`, like [{{ radarr['cf']['freeleech']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ radarr['cf']['p2p-internal']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"}, is enough on its own. For example, you grab a non-freeleech release (`1600`), the same release later appears as freeleech on another indexer (`1601`), and Radarr re-downloads it as an "upgrade".
 
-    A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Radarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
+    This is an expected edge case. The fix is by [cross-seeding](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}: the freeleech copy is linked to your existing download instead of being grabbed again, so it can't trigger an upgrade.
 
-    This is an expected edge case rather than a bug, and the recommended way to avoid it is **[cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}**. With cross-seed the alternate (freeleech) copy of a release you already have is linked to your existing download instead of being grabbed again, so it can never trigger this kind of upgrade — and you still get the freeleech/ratio benefit.
-
-    Raising the `Minimum Custom Format Score Increment` in your Quality Profile above `1` will also stop it, but we don't recommend it as a first step: it changes how *every* Custom Format triggers upgrades, and if you sync scores with a tool you'll need to account for the change.
+    Raising the `Minimum Custom Format Score Increment` above `1` also works, but it affects every Custom Format and isn't recommended as a first step.
 
 ### Audio Channels
 

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -349,6 +349,21 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
     Also, it makes it much more clear what you prefer and what you want to avoid.
 
+### Unwanted upgrades from single-point Custom Formats
+
+??? warning "Unwanted upgrades from single-point Custom Formats - [Click to show/hide]"
+
+    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`. This means a release only needs to score **1 point higher** than what you already have before Radarr treats it as an upgrade.
+
+    Because of this, a Custom Format worth only `+1` — such as [{{ radarr['cf']['freeleech']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ radarr['cf']['p2p-internal']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"} — is enough on its own to trigger an upgrade.
+
+    A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Radarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
+
+    This is an expected edge case rather than a bug. If you want to avoid it:
+
+    - Use [cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"} so the release is already in your library and can't be grabbed again, **or**
+    - Raise the `Minimum Custom Format Score Increment` in your Quality Profile above `1`. Keep in mind this affects how *every* Custom Format triggers upgrades, so if you sync scores with a tool you'll need to account for the change.
+
 ### Audio Channels
 
 ??? info "Audio Channels - [Click to show/hide]"

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -359,10 +359,9 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
     A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Radarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
 
-    This is an expected edge case rather than a bug. If you want to avoid it:
+    This is an expected edge case rather than a bug, and the recommended way to avoid it is **[cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}**. With cross-seed the alternate (freeleech) copy of a release you already have is linked to your existing download instead of being grabbed again, so it can never trigger this kind of upgrade — and you still get the freeleech/ratio benefit.
 
-    - Use [cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"} so the release is already in your library and can't be grabbed again, **or**
-    - Raise the `Minimum Custom Format Score Increment` in your Quality Profile above `1`. Keep in mind this affects how *every* Custom Format triggers upgrades, so if you sync scores with a tool you'll need to account for the change.
+    Raising the `Minimum Custom Format Score Increment` in your Quality Profile above `1` will also stop it, but we don't recommend it as a first step: it changes how *every* Custom Format triggers upgrades, and if you sync scores with a tool you'll need to account for the change.
 
 ### Audio Channels
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -258,6 +258,21 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
     Also, it makes it much more clear what you prefer and what you want to avoid.
 
+### Unwanted upgrades from single-point Custom Formats
+
+??? warning "Unwanted upgrades from single-point Custom Formats - [Click to show/hide]"
+
+    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`. This means a release only needs to score **1 point higher** than what you already have before Sonarr treats it as an upgrade.
+
+    Because of this, a Custom Format worth only `+1` — such as [{{ sonarr['cf']['freeleech']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ sonarr['cf']['p2p-internal']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"} — is enough on its own to trigger an upgrade.
+
+    A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Sonarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
+
+    This is an expected edge case rather than a bug. If you want to avoid it:
+
+    - Use [cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"} so the release is already in your library and can't be grabbed again, **or**
+    - Raise the `Minimum Custom Format Score Increment` in your Quality Profile above `1`. Keep in mind this affects how *every* Custom Format triggers upgrades, so if you sync scores with a tool you'll need to account for the change.
+
 ### Audio Channels
 
 ??? info "Audio Channels - [Click to show/hide]"

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -268,10 +268,9 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
     A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Sonarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
 
-    This is an expected edge case rather than a bug. If you want to avoid it:
+    This is an expected edge case rather than a bug, and the recommended way to avoid it is **[cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}**. With cross-seed the alternate (freeleech) copy of a release you already have is linked to your existing download instead of being grabbed again, so it can never trigger this kind of upgrade — and you still get the freeleech/ratio benefit.
 
-    - Use [cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"} so the release is already in your library and can't be grabbed again, **or**
-    - Raise the `Minimum Custom Format Score Increment` in your Quality Profile above `1`. Keep in mind this affects how *every* Custom Format triggers upgrades, so if you sync scores with a tool you'll need to account for the change.
+    Raising the `Minimum Custom Format Score Increment` in your Quality Profile above `1` will also stop it, but we don't recommend it as a first step: it changes how *every* Custom Format triggers upgrades, and if you sync scores with a tool you'll need to account for the change.
 
 ### Audio Channels
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -262,15 +262,13 @@ This is a must-have for every Quality Profile you use in our opinion. All these 
 
 ??? warning "Unwanted upgrades from single-point Custom Formats - [Click to show/hide]"
 
-    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`. This means a release only needs to score **1 point higher** than what you already have before Sonarr treats it as an upgrade.
+    Our Quality Profiles use a `Minimum Custom Format Score Increment` of `1`, so a release only needs `+1` more than what you already have to count as an upgrade.
 
-    Because of this, a Custom Format worth only `+1` — such as [{{ sonarr['cf']['freeleech']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ sonarr['cf']['p2p-internal']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"} — is enough on its own to trigger an upgrade.
+    A Custom Format worth only `+1`, like [{{ sonarr['cf']['freeleech']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#freeleech){:target="\_blank" rel="noopener noreferrer"} or [{{ sonarr['cf']['p2p-internal']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#p2p-internal){:target="\_blank" rel="noopener noreferrer"}, is enough on its own. For example, you grab a non-freeleech release (`1600`), the same release later appears as freeleech on another indexer (`1601`), and Sonarr re-downloads it as an "upgrade".
 
-    A common example: you grab a release that isn't freeleech (a score of `1600`), and later the **exact same release** is uploaded as freeleech on another indexer (`1601`). Sonarr sees the higher score and re-downloads it as an "upgrade", even though it's effectively the same file.
+    This is an expected edge case. The fix is by [cross-seeding](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}: the freeleech copy is linked to your existing download instead of being grabbed again, so it can't trigger an upgrade.
 
-    This is an expected edge case rather than a bug, and the recommended way to avoid it is **[cross-seed](https://www.cross-seed.org/){:target="\_blank" rel="noopener noreferrer"}**. With cross-seed the alternate (freeleech) copy of a release you already have is linked to your existing download instead of being grabbed again, so it can never trigger this kind of upgrade — and you still get the freeleech/ratio benefit.
-
-    Raising the `Minimum Custom Format Score Increment` in your Quality Profile above `1` will also stop it, but we don't recommend it as a first step: it changes how *every* Custom Format triggers upgrades, and if you sync scores with a tool you'll need to account for the change.
+    Raising the `Minimum Custom Format Score Increment` above `1` also works, but it affects every Custom Format and isn't recommended as a first step.
 
 ### Audio Channels
 


### PR DESCRIPTION
Add a warning to the Radarr and Sonarr quality profile guides covering an upgrade edge case.

With a `Minimum Custom Format Score Increment` of `1` (the value our Quality Profiles use), a Custom Format worth only `+1` — such as FreeLeech or P2P Internal — is enough on its own to trigger an upgrade. This explains the common case where the same release later appears as freeleech on another indexer (e.g. 1600 → 1601) and gets re-downloaded.

The note recommends cross-seeding as the fix, and mentions raising the increment above `1` as a secondary option.